### PR TITLE
fix: add user address to the signature for claimRewards

### DIFF
--- a/contracts/PookyGame.sol
+++ b/contracts/PookyGame.sol
@@ -189,7 +189,17 @@ contract PookyGame is AccessControlUpgradeable {
     uint256 nonce,
     bytes memory signature
   ) external {
-    if (!verifySignature(abi.encode(amountNative, amountPOK, ballUpdates, ttl, nonce), signature)) {
+    if (!verifySignature(
+      abi.encode(
+        msg.sender, 
+        amountNative, 
+        amountPOK, 
+        ballUpdates, 
+        ttl, 
+        nonce
+      ), 
+      signature
+    )) {
       revert InvalidSignature();
     }
 

--- a/lib/utils/signRewardsClaim.ts
+++ b/lib/utils/signRewardsClaim.ts
@@ -3,6 +3,7 @@ import { BigNumberish, Signer, utils } from 'ethers';
 
 /**
  * Sign the reward claim payload.
+ * @param userAddress The address of the user who is claiming the reward.
  * @param rewardNAT The amount of native currency to claim.
  * @param rewardPOK The amount of POK to claim.
  * @param ballUpdates The balls updates (PXP, level up).
@@ -11,6 +12,7 @@ import { BigNumberish, Signer, utils } from 'ethers';
  * @param signer The ethers.js signer.
  */
 export async function signRewardsClaim(
+  userAddress: string,
   rewardNAT: BigNumberish,
   rewardPOK: BigNumberish,
   ballUpdates: BallUpdatesStruct[],
@@ -19,8 +21,15 @@ export async function signRewardsClaim(
   signer: Signer,
 ): Promise<string> {
   const message = utils.defaultAbiCoder.encode(
-    ['uint256', 'uint256', 'tuple(uint256 tokenId, uint256 addPXP, bool shouldLevelUp)[]', 'uint256', 'uint256'],
-    [rewardNAT, rewardPOK, ballUpdates, ttl, nonce],
+    [
+      'address',
+      'uint256',
+      'uint256',
+      'tuple(uint256 tokenId, uint256 addPXP, bool shouldLevelUp)[]',
+      'uint256',
+      'uint256',
+    ],
+    [userAddress, rewardNAT, rewardPOK, ballUpdates, ttl, nonce],
   );
   const hash = utils.keccak256(message);
   return signer.signMessage(utils.arrayify(hash));

--- a/test/PookyGame.spec.ts
+++ b/test/PookyGame.spec.ts
@@ -251,7 +251,7 @@ describe('PookyGame', () => {
     });
 
     it('should allow players to claim POK', async () => {
-      const signature = await signRewardsClaim(rewardNAT, rewardPOK, [], ttl, nonce, backend);
+      const signature = await signRewardsClaim(player1.address, rewardNAT, rewardPOK, [], ttl, nonce, backend);
 
       await expect(
         PookyGame.connect(player1).claimRewards(rewardNAT, rewardPOK, [], ttl, nonce, signature),
@@ -259,7 +259,7 @@ describe('PookyGame', () => {
     });
 
     it('should allow players to claim POK and add PXP to an existing ball', async () => {
-      const signature = await signRewardsClaim(rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
+      const signature = await signRewardsClaim(player1.address, rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
 
       await expect(PookyGame.connect(player1).claimRewards(rewardNAT, rewardPOK, ballUpdates, ttl, nonce, signature)).to
         .not.be.reverted;
@@ -268,7 +268,7 @@ describe('PookyGame', () => {
     });
 
     it('should revert if user tries to claim rewards with an invalid signature', async () => {
-      const signature = await signRewardsClaim(rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
+      const signature = await signRewardsClaim(player1.address, rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
 
       await expect(
         PookyGame.connect(player1).claimRewards(
@@ -284,9 +284,25 @@ describe('PookyGame', () => {
         .withArgs();
     });
 
+    it('should revert if user tries to claim rewards with signature from another user', async () => {
+      const signature = await signRewardsClaim(player2.address, rewardNAT, rewardPOK, [], ttl, nonce, backend);
+
+      await expect(PookyGame.connect(player1).claimRewards(rewardNAT, rewardPOK, [], ttl, nonce, signature))
+        .to.be.revertedWithCustomError(PookyGame, 'InvalidSignature')
+        .withArgs();
+    });
+
     it('should revert if reward claim has expired', async () => {
       const expiredTimestamp = currentTimestamp - 100;
-      const signature = await signRewardsClaim(rewardNAT, rewardPOK, ballUpdates, expiredTimestamp, nonce, backend);
+      const signature = await signRewardsClaim(
+        player1.address,
+        rewardNAT,
+        rewardPOK,
+        ballUpdates,
+        expiredTimestamp,
+        nonce,
+        backend,
+      );
 
       await expect(
         PookyGame.connect(player1).claimRewards(rewardNAT, rewardPOK, ballUpdates, expiredTimestamp, nonce, signature),
@@ -296,7 +312,7 @@ describe('PookyGame', () => {
     });
 
     it('should revert if nonce has already been used', async () => {
-      const signature = await signRewardsClaim(rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
+      const signature = await signRewardsClaim(player1.address, rewardNAT, rewardPOK, ballUpdates, ttl, nonce, backend);
 
       // First call: success!
       await expect(PookyGame.connect(player1).claimRewards(rewardNAT, rewardPOK, ballUpdates, ttl, nonce, signature)).to


### PR DESCRIPTION
Adding the user's address as the first parameter of the signature when claiming rewards. In the contract we are using the address of the transaction sender to verify if the signature is valid for it.

Without it, somebody can use a signature which was made for another user, if he manages to send the transaction before other user (for example by looking at the mempool of transactions and sending the same transaction with a valid signature but a higher gas fee)