### PR TITLE
feat(Pookyball): allow to change the ERC2891 royalties recipient

### DIFF
--- a/contracts/game/Level.sol
+++ b/contracts/game/Level.sol
@@ -99,7 +99,7 @@ contract Level {
   /**
    * @notice Level up a Pookyball in exchange of a certain amount of $POK token.
    * @dev Requirements
-   * - msg.sender must be the owner of Pookyball tokenId.
+   * - msg.sender must be the owner of Pookyball `tokenId`.
    * - msg.sender must own enough $POK tokens to pay the level up fee.
    * - Pookyball level should be strictly less than the maximum allowed level for its rarity.
    */

--- a/contracts/interfaces/IPookyball.sol
+++ b/contracts/interfaces/IPookyball.sol
@@ -31,6 +31,11 @@ interface IPookyball is IAccessControl, IERC2981, IERC721 {
   function metadata(uint256 tokenId) external view returns (PookyballMetadata memory);
 
   /**
+   * @notice Change the secondary sale royalties receiver address.
+   */
+  function setERC2981Receiver(address newReceiver) external;
+
+  /**
    * @notice Mint a new Pookyball token with a given rarity and luxury.
    */
   function mint(

--- a/contracts/tokens/Pookyball.sol
+++ b/contracts/tokens/Pookyball.sol
@@ -36,6 +36,9 @@ contract Pookyball is IPookyball, ERC721, ERC2981, AccessControl, VRFConsumerBas
   bytes32 public constant MINTER = keccak256("MINTER");
   bytes32 public constant GAME = keccak256("GAME");
 
+  /// Secondary sales royalties, over 10,000 (5%)
+  uint96 public constant ROYALTY = 500;
+
   /**
    * @notice The prefix of all the Pookyball metadata.
    */
@@ -64,7 +67,7 @@ contract Pookyball is IPookyball, ERC721, ERC2981, AccessControl, VRFConsumerBas
   constructor(
     string memory _baseURI,
     string memory _contractURI,
-    address _treasury,
+    address _receiver,
     address _vrfCoordinator,
     bytes32 _vrfKeyHash,
     uint64 _vrfSubId,
@@ -80,7 +83,7 @@ contract Pookyball is IPookyball, ERC721, ERC2981, AccessControl, VRFConsumerBas
     vrfMinimumRequestConfirmations = _vrfMinimumRequestConfirmations;
     vrfCallbackGasLimit = _vrfCallbackGasLimit;
 
-    _setDefaultRoyalty(_treasury, 500);
+    _setDefaultRoyalty(_receiver, ROYALTY);
     _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
   }
 
@@ -123,6 +126,15 @@ contract Pookyball is IPookyball, ERC721, ERC2981, AccessControl, VRFConsumerBas
   function metadata(uint256 tokenId) external view returns (PookyballMetadata memory) {
     _requireMinted(tokenId);
     return _metadata[tokenId];
+  }
+
+  /**
+   * @notice Change the secondary sale royalties receiver address.
+   * @dev Requirements:
+   * - Only DEFAULT_ADMIN_ROLE role can set base URI.
+   */
+  function setERC2981Receiver(address newReceiver) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    _setDefaultRoyalty(newReceiver, ROYALTY);
   }
 
   /**

--- a/lib/config/mainnet.ts
+++ b/lib/config/mainnet.ts
@@ -10,11 +10,15 @@ const mainnet: Config = {
   verify: true,
 
   accounts: {
-    treasury: '0x96224b6a800294f40c547f7ec0952ea222526040',
     admin: '0x3CC4F4372F83ad3C577eD6e1Aae3D244A1b955D5',
+    treasury: {
+      primary: '0x96224b6a800294f40c547f7ec0952ea222526040',
+      secondary: '',
+    },
     backend: constants.AddressZero, // TBD
     operators: [
       '0xe73b648f6de254101052e126c0499c32ed736a37', // Mathieu Bour (windyy.eth)
+      '0x3C3Bc507Ff3e4Afb96538d2Bf3f5D421aE3933F4', // Mathieu Bour (Pooky)
       '0x481074326aC46C7BC52f0b25D2F7Aaf40f586472', // Pierre Gerbaud (pierregerbaud.eth)
     ],
   },

--- a/lib/config/mumbai.ts
+++ b/lib/config/mumbai.ts
@@ -11,7 +11,10 @@ const mumbai: Config = {
 
   accounts: {
     ...mainnet.accounts,
-    treasury: '0x2dfCa6e357a73D180B8e6aa8f7690A315a4395F7',
+    treasury: {
+      primary: '0x2dfCa6e357a73D180B8e6aa8f7690A315a4395F7',
+      secondary: '0x2dfCa6e357a73D180B8e6aa8f7690A315a4395F7',
+    },
     admin: '0xF00Db2f08D1F6b3f6089573085B5826Bb358e319',
     backend: '0xCAFE3e690bf74Ec274210E1c448130c1f8228513',
   },

--- a/lib/deployContracts.ts
+++ b/lib/deployContracts.ts
@@ -62,7 +62,7 @@ export async function deployContracts(signer: SignerWithAddress, options: Config
     Pookyball__factory,
     options.metadata.baseURI,
     options.metadata.contractURI,
-    options.accounts.treasury,
+    options.accounts.treasury.secondary,
     options.vrf.coordinator,
     options.vrf.keyHash,
     options.vrf.subId,
@@ -79,7 +79,7 @@ export async function deployContracts(signer: SignerWithAddress, options: Config
     GenesisMinter__factory,
     Pookyball.address,
     WaitList.address,
-    options.accounts.treasury,
+    options.accounts.treasury.primary,
     templates,
   );
   await GenesisMinter.deployed();

--- a/lib/testing/stackFixture.ts
+++ b/lib/testing/stackFixture.ts
@@ -26,7 +26,10 @@ export default async function stackFixture() {
     ...testing,
     accounts: {
       admin: admin.address,
-      treasury: treasury.address,
+      treasury: {
+        primary: treasury.address,
+        secondary: treasury.address,
+      },
       backend: rewarder.address,
       operators: [operator.address],
     },

--- a/lib/types/Config.ts
+++ b/lib/types/Config.ts
@@ -13,7 +13,11 @@ export default interface Config {
 
   accounts: {
     admin: string;
-    treasury: string;
+    treasury: {
+      primary: string;
+      secondary: string;
+    };
+
     backend: string;
     operators?: string[];
   };


### PR DESCRIPTION
The PR introduces the `Pookyball.setERC2981Receiver` function.

```solidity
/**
 * @notice Change the secondary sale royalties receiver address.
 */
function setERC2981Receiver(address newReceiver) external;
```